### PR TITLE
Fixed 3.1.1 Section of TrafficLightSimulation.py

### DIFF
--- a/Traffic Simulation/TrafficLightSimulation.py
+++ b/Traffic Simulation/TrafficLightSimulation.py
@@ -69,16 +69,23 @@ def trafficLightInteraction (trafficLight, vehicles, light_index):
 
         # 3.1.1 THEN IF the first vehicle in front of the light is in the deceleration distance
         distance = trafficLight_position - vehicles[0]["position"] # Calculate distance between traffic light & first vehicle position
-        if distance > 0.0 and distance < VehicleCalculations.decelerationDistance:
-            # Apply the deceleration factor to the first vehicle and all vehicles behind it within the deceleration distance
-            first_vehicle_index = 0
-            while first_vehicle_index < len(vehicles) and vehicles[first_vehicle_index]["position"] >= trafficLight_position:
-                first_vehicle_index += 1
-
-            for i in range(first_vehicle_index):
+        closest_vehicle_index = 0
+        closest_vehicle_distance = abs(trafficLight_position - vehicles[0]["position"])
+        for i in range(1, len(vehicles)):
+            # Calculate the distance between the traffic light and the current vehicle
+            distance_to_traffic_light = abs(trafficLight_position - vehicles[i]["position"])
+            # If the current vehicle is closer to the traffic light than the previous closest vehicle, update the closest vehicle
+            if distance_to_traffic_light < closest_vehicle_distance:
+                closest_vehicle_index = i
+                closest_vehicle_distance = distance_to_traffic_light
+        if closest_vehicle_distance > 0.0 and closest_vehicle_distance < VehicleCalculations.decelerationDistance:
+            # Apply the deceleration factor to the closest vehicle and all vehicles behind it within the deceleration distance
+            for i in range(closest_vehicle_index, len(vehicles)):
                 distance_to_traffic_light = trafficLight_position - vehicles[i]["position"]
                 if distance_to_traffic_light <= VehicleCalculations.decelerationDistance:
                     VehicleCalculations.applyDecelerationFactor(vehicles, i)
+                    # Debug print
+                    # print("Applied Deceleration Factor to Vehicle: ", vehicles[i]["type"])
 
         # 3.1.2 ELSE IF the first vehicle in front of the light is in the first half of the stopping distance
         elif distance > (VehicleCalculations.stoppingDistance / 2) and distance < VehicleCalculations.stoppingDistance:


### PR DESCRIPTION
**TrafficLightSimulation.py:**
- Removed the while loop and replaced it with a for loop to find the closest vehicle to the traffic light within 3.1.1
- Added a new variable "closest_vehicle_distance" to keep track of the distance between the closest vehicle and the traffic light within 3.1.1
- Replaced the condition in the if statement to check the distance of the closest vehicle instead of the first vehicle within 3.1.1
- Changed the range of the for loop to start from the closest vehicle index instead of the first vehicle index within 3.1.1

Fixed the issue of accessing **vehicles[0]** instead of accessing the actual vehicle that is behind the traffic light by iterating through the vehicles list to find the first vehicle behind the traffic light and applying the deceleration factor to it and any vehicles behind it within the deceleration distance.

Fixed the issue of **vehicles[i]** never entering the conditional statement to apply the deceleration to itself, this is because the conditional statement was accessing a range out of bounds.

_Please note that I am **not** observing a change in speed when deceleration is applied to a given vehicle._