### PR TITLE
Fixed TypeError bug within BusStopSimulation.py

### DIFF
--- a/Traffic Simulation/BusStopSimulation.py
+++ b/Traffic Simulation/BusStopSimulation.py
@@ -72,8 +72,17 @@ def busStopSimulation(busStop, vehicles, busStopIndex):
                             print("| Bus Elapsed Time", elapsedTime)
                             print("______________________________________________________\n")
                     
-                    # 3 IF time since vehicle with bus type stopped > waiting time   
-                    if elapsedTime > busStop[busStopIndex]["waitingtime"]:
+                    # 3 IF time since vehicle with bus type stopped > waiting time
+
+                    # Convert elapsedTime to an int to allow the the comparison with busStop[busStopIndex]["waitingtime"]
+                    if isinstance(elapsedTime, datetime.datetime):
+                        # If elapsedTime is a datetime object, convert it to an int
+                        elapsedTimeComparison = int(elapsedTime.timestamp())
+                    else:
+                        # Else, already an int
+                        elapsedTimeComparison = elapsedTime
+
+                    if elapsedTimeComparison > busStop[busStopIndex]["waitingtime"]:
                         # 3.1 THEN the vehicle may depart 
                         # Change bus position to leave bus stop   
                         vehicles[i]["position"] = busStop_position + 0.1              

--- a/Traffic Simulation/BusStopSimulation.py
+++ b/Traffic Simulation/BusStopSimulation.py
@@ -62,7 +62,12 @@ def busStopSimulation(busStop, vehicles, busStopIndex):
                                 # Set the waiting time of the indexed bus back to zero since it has arrived
                                 busStop[busStopIndex]["waitingtime"] = 0
                             else:
-                                difference_time = datetime.datetime.now() - stopTimes[busStop_road]
+                                # Check to see if stop_time is an int, then convert to a datatime.datatime object
+                                stop_time = stopTimes[busStop_road]
+                                if isinstance(stop_time, int):
+                                    stop_time = datetime.datetime.fromtimestamp(stop_time)
+                                
+                                difference_time = datetime.datetime.now() - stop_time
                                 elapsedTime = difference_time.total_seconds()
                             print("______________________________________________________")
                             print("| BUS AT BUS STOP                                     ")


### PR DESCRIPTION
**BusStopSimulation.py**

- Fixed TypeError: '>' not supported between instances of 'int' and 'datetime.datetime' bug
- Introduced a new variable called _elapsedTimeComparison_ that will store an integer version of _elaspedTime_
- New if statement before comparison to convert _elaspedTime_ into an int if _elaspedTime_ is a 'datetime.datetime' object
- This resolves the issue of _busStop[busStopIndex]["waitingtime"]_ being compared to a 'datetime.datetime' object


Please note that line 63 can be removed if we change the wait times for the bus as I believe 20 is too high. Without line 63, section 3.0 of **BusStopSimulation.py** will never execute. 